### PR TITLE
feat: added local-ip script

### DIFF
--- a/local-ip
+++ b/local-ip
@@ -1,0 +1,7 @@
+source "$NOAHJAHN_UTILS_DIR/scripts/bash/validate-binary.sh"
+
+ip=$(_validate_binary ip)
+
+open_dns_ip=208.67.222.222
+
+$ip route get $open_dns_ip | sed -n '/src/{s/.*src *\([^ ]*\).*/\1/p;q}'


### PR DESCRIPTION
## Features

- Added a `local-ip` script, which should output whatever your local-ip is when you call it from somewhere! super helpful for replacing `host.docker.internal` (I think that's what I was using it for, don't remember at this point)

I did notice an "issue" (I don't have the brain power to figure out if this is an actual issue or if it's actually a good thing) with this when you're on a VPN/have multiple local IPs. It was returning my VPN's local IP